### PR TITLE
switch react to a peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "webpack": "^1.4.7",
     "webpack-dev-server": "^1.6.5"
   },
-  "dependencies": {
+  "peerDependencies": {
     "react": "~0.13.x"
   }
 }


### PR DESCRIPTION
components aren't supposed to have a hard dependency on react, otherwise the version flexibility goes out the door