### PR TITLE
Fix for issue #13

### DIFF
--- a/lib/ReactFitText.js
+++ b/lib/ReactFitText.js
@@ -32,6 +32,7 @@ module.exports = React.createClass({
 
   componentDidMount: function() {
     window.addEventListener("resize", this._onBodyResize);
+    this._onBodyResize();
   },
 
   componentWillUnmount: function() {

--- a/lib/ReactFitText.js
+++ b/lib/ReactFitText.js
@@ -32,7 +32,6 @@ module.exports = React.createClass({
 
   componentDidMount: function() {
     window.addEventListener("resize", this._onBodyResize);
-    this._onBodyResize();
   },
 
   componentWillUnmount: function() {
@@ -40,15 +39,19 @@ module.exports = React.createClass({
   },
 
   _onBodyResize: function() {
-    var element = this.getDOMNode();
+    var element = this._childRef;
     var width = element.offsetWidth;
     element.style.fontSize = Math.max(
                       Math.min((width / (this.props.compressor*10)),
                                 parseFloat(this.props.maxFontSize)),
                       parseFloat(this.props.minFontSize)) + 'px';
   },
-
+  _renderChildren: function(){
+    return React.Children.map(this.props.children, child =>
+      React.cloneElement(child,{ref:(c) => this._childRef = c})
+    );
+  },
   render: function() {
-    return this.props.children;
+    return this._renderChildren()[0];
   }
 });


### PR DESCRIPTION
This should fix the issue with "Uncaught Invariant Violation: traverseParentPath..." It's applying a reference callback to the react objects children. This could also be a way to only apply the resize event listener to specific elements types.

I think I'm going to branch off and try to have a global wrapper and see what type of performance hit the page takes.