### PR TITLE
Fix _renderChildren error in Safari.

### DIFF
--- a/lib/ReactFitText.js
+++ b/lib/ReactFitText.js
@@ -48,9 +48,13 @@ module.exports = React.createClass({
                       parseFloat(this.props.minFontSize)) + 'px';
   },
   _renderChildren: function(){
-    return React.Children.map(this.props.children, child =>
-      React.cloneElement(child,{ref:(c) => this._childRef = c})
-    );
+    var _this = this;
+
+    return React.Children.map(this.props.children, function (child) {
+      return React.cloneElement(child, { ref: function ref(c) {
+        return _this._childRef = c;
+      } });
+    });
   },
   render: function() {
     return this._renderChildren()[0];


### PR DESCRIPTION
Fixes the error in Safari due to use of arrow functions.

