### PR TITLE
Ratio based switching to height relative resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ If you want to see a live demo of this component, you can [check the homepage](h
 ## Thanks
 * [KyleAMathews](https://github.com/KyleAMathews)
 * [revolunet](https://github.com/revolunet)
+* [poteto](https://github.com/poteto)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-fittext",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A React plugin to fit the text in the screen",
   "main": "lib/ReactFitText.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-fittext",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A React plugin to fit the text in the screen",
   "main": "lib/ReactFitText.js",
   "scripts": {


### PR DESCRIPTION
Why not Add the ability to switch resize mode according to the height of the container div above a pre-determined aspect ratio.

Adding switchRatio parameter. User can pass this parameter if he wants the text size to fit the height of the div above this given ratio.
Adding heightCompressor parameter to control the text size according to the height.
Modifying "compressor" parameter name to "widthCompressor" for coherency purpose

usage :
<ReactFitText **switchRatio={2.8} heightCompressor={0.1}** widthCompressor={0.2}>
  <div>
    test
  </div>
</ReactFitText>
          

[ReactFitText.zip](https://github.com/gianu/react-fittext/files/851028/ReactFitText.zip)
