### PR TITLE
Added event listener onLoad to resize text correctly when refresh

### DIFF
--- a/lib/ReactFitText.js
+++ b/lib/ReactFitText.js
@@ -34,11 +34,13 @@ module.exports = createClass({
 
   componentDidMount: function() {
     window.addEventListener("resize", this._onBodyResize);
+    window.addEventListener("load", this._onBodyResize);
     this._onBodyResize();
   },
 
   componentWillUnmount: function() {
     window.removeEventListener("resize", this._onBodyResize);
+    window.removeEventListener("load", this._onBodyResize);
   },
 
   componentDidUpdate: function() {


### PR DESCRIPTION
As you can see, if the resize function is not triggered at the "load" event, when page refresh this is the result:

![screenshot-localhost-3000-2017-08-12-17-22-30](https://user-images.githubusercontent.com/8423260/29243984-5e13a174-7f83-11e7-9696-5558026b921e.png)

If i resize the page, the text fontSize property is set correctly:

![screenshot-localhost-3000-2017-08-12-17-20-35](https://user-images.githubusercontent.com/8423260/29243994-a3852b9c-7f83-11e7-88b6-8a8a7a645588.png)

So, adding event listener to "load" event fix this issue. Cheers!
