### PR TITLE
Sweeping performance improvements and onload resizing

### DIFF
--- a/lib/ReactFitText.js
+++ b/lib/ReactFitText.js
@@ -34,11 +34,13 @@ module.exports = createClass({
 
   componentDidMount: function() {
     window.addEventListener("resize", this._onBodyResize);
+    window.addEventListener("load", this._onBodyResize);
     this._onBodyResize();
   },
 
   componentWillUnmount: function() {
     window.removeEventListener("resize", this._onBodyResize);
+    window.removeEventListener("load", this._onBodyResize);
   },
 
   componentDidUpdate: function() {

--- a/lib/ReactFitText.js
+++ b/lib/ReactFitText.js
@@ -14,6 +14,31 @@ var ReactDOM = require('react-dom');
 var ReactPropTypes = require('prop-types');
 var createClass = require('create-react-class');
 
+// Map from node to options
+const nodes = new Map();
+
+function updateElementStyle(element, options, width) {
+  element.style.fontSize = `${Math.min(Math.max(width / (options.compressor * 10), options.minFontSize), options.maxFontSize)}px`;
+}
+
+let updateQueued = false;
+
+function onBodyResize() {
+  updateQueued = true;
+  const widths = [];
+  nodes.forEach((options, element) => {
+    widths.push(element.offsetWidth);
+  });
+  let i = 0;
+  nodes.forEach((options, element) => {
+    updateElementStyle(element, options, widths[i]);
+    i += 1;
+  });
+}
+
+window.addEventListener("resize", onBodyResize);
+window.addEventListener("load", onBodyResize);
+
 module.exports = createClass({
   displayName: 'ReactFitText',
 
@@ -21,7 +46,7 @@ module.exports = createClass({
     children: ReactPropTypes.element.isRequired,
     compressor: ReactPropTypes.number,
     minFontSize: ReactPropTypes.number,
-    maxFontSize: ReactPropTypes.number
+    maxFontSize: ReactPropTypes.number,
   },
 
   getDefaultProps: function() {
@@ -32,35 +57,31 @@ module.exports = createClass({
     };
   },
 
-  componentDidMount: function() {
-    window.addEventListener("resize", this._onBodyResize);
-    window.addEventListener("load", this._onBodyResize);
-    this._onBodyResize();
+  componentWillMount: function() {
+    if (!updateQueued) {
+      window.requestAnimationFrame(onBodyResize);
+    }
   },
 
   componentWillUnmount: function() {
-    window.removeEventListener("resize", this._onBodyResize);
-    window.removeEventListener("load", this._onBodyResize);
+    if (this._childRef) {
+      nodes.delete(this._childRef);
+    }
   },
 
   componentDidUpdate: function() {
-    this._onBodyResize();
+    onBodyResize();
   },
 
-  _onBodyResize: function() {
-    var element = ReactDOM.findDOMNode(this);
-    var width = element.offsetWidth;
-    element.style.fontSize = Math.max(
-                      Math.min((width / (this.props.compressor*10)),
-                                parseFloat(this.props.maxFontSize)),
-                      parseFloat(this.props.minFontSize)) + 'px';
-  },
   _renderChildren: function(){
     var _this = this;
 
     return React.Children.map(this.props.children, function (child) {
       return React.cloneElement(child, { ref: function ref(c) {
-        return _this._childRef = c;
+        if (c) {
+          nodes.set(c, _this.props);
+        }
+        _this._childRef = c;
       } });
     });
   },


### PR DESCRIPTION
The pull request (in two separate commits) does the following:

## Commit 1 (correctness pass)

Update elements in response to onload in addition to on resize to prevent stale sizing if layout is changed as a result of a script or element being loaded downstream. (authorship Kip Ricker, a coworker of mine)

## Commit 2 (performance pass)

- Elide unnecessary findDOMNode which is unnecessary since you already grab the element reference and this function performs poorly with other React replacements that manipulate the DOM more directly instead of indirect id lookups a la React.
- Uses a *single* event listener for resize and onload events instead of one per component
- Remove the read/write update cycle that occurs in the onBodyResize_ callback. The original code required each text element update to *force a relayout* of the page. What is done instead is all element widths are read once in a batch and font stylings are applied after in a batch.
- Defer layout to the first animation frame after the initial mount. This will give the element layout a better chance of "settling" before all the font sizes get calculated on the initial run

Benchmark:

On a page with ~200 text elements, the render time went from 6 seconds on an iphone 7 to 30 ms. From a big-O standpoint, the algorithmic complexity is now O(n) compared to O(n^3)