### PR TITLE
Updates dependencies and peerDependencies

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -6,7 +6,7 @@ var Path = require("path"),
     webpackConfig,
 
     IS_PRODUCTION = "production" === process.env.NODE_ENV,
-    JSX_WITH_HOT_LOEADERS = ["react-hot-loader", "babel-loader?optional=runtime"],
+    JSX_WITH_HOT_LOEADERS = ["react-hot-loader/webpack", "babel-loader?optional=runtime"],
     CSS_LOADER = "style-loader!css-loader?root=../",
 
 webpackConfig = module.exports = {

--- a/package.json
+++ b/package.json
@@ -35,29 +35,29 @@
     "css-loader": "^0.9.0",
     "expose-loader": "^0.5.3",
     "file-loader": "^0.8.1",
-    "gulp": "~3.8.5",
-    "gulp-jshint": "^1.9.0",
-    "gulp-react": "^2.0.0",
+    "gulp": "~3.9.1",
+    "gulp-jshint": "^2.1.0",
+    "gulp-react": "^3.1.0",
     "gulp-util": "^3.0.1",
     "html-webpack-plugin": "^1.6.1",
     "nib": "^1.1.0",
-    "react": "^15.0.0",
-    "react-dom": "^15.0.0",
-    "react-hot-loader": "^1.3.0",
-    "run-sequence": "^1.0.2",
+    "react": "^16.5.2",
+    "react-dom": "^16.5.2",
+    "react-hot-loader": "3.1.1",
+    "run-sequence": "^2.2.1",
     "style-loader": "^0.12.4",
-    "stylus": "^0.52.4",
+    "stylus": "^0.54.5",
     "stylus-loader": "^1.3.0",
     "url-loader": "^0.5.5",
     "webpack": "^1.4.7",
     "webpack-dev-server": "^1.6.5"
   },
   "peerDependencies": {
-    "react": "^15.0.0",
-    "react-dom": "^15.0.0"
+    "react": ">=15.0.0",
+    "react-dom": ">=15.0.0"
   },
   "dependencies": {
-    "create-react-class": "^15.5.3",
-    "prop-types": "^15.5.10"
+    "create-react-class": ">=15.5.3",
+    "prop-types": ">=15.5.10"
   }
 }


### PR DESCRIPTION
Not all dependencies could be updated to their latest versions without
some major changes, but enough of them could so dev can run against
react 16.
Also updates peerDependencies to allow using in projects that use react
16.

Related to #26.